### PR TITLE
feat(terraform): allow optional Helm chart version specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_always_update"></a> [always\_update](#input\_always\_update) | Set this to true value trigger a Helm chart update | `bool` | `false` | no |
 | <a name="input_chart_name"></a> [chart\_name](#input\_chart\_name) | Name of the chart | `string` | n/a | yes |
-| <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Version of the chart | `string` | n/a | yes |
+| <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Version of the Helm chart to install. If not specified, the latest version will be used. | `string` | `""` | no |
 | <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Create the namespace if it does not exist. Defaults to false | `bool` | `false` | no |
 | <a name="input_kubeconfig_json"></a> [kubeconfig\_json](#input\_kubeconfig\_json) | Kubeconfig JSON | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace to install the chart | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,11 @@
-
 locals {
+  # Get latest version if chart_version is not specified
+  helm_version_flag = var.chart_version != "" ? "--version ${var.chart_version}" : ""
+
   # Helm command configuration
   helm_command = <<-EOT
     helm upgrade --install ${var.release_name} ${var.repo_name}/${var.chart_name} \
-      --version ${var.chart_version} \
+      ${local.helm_version_flag} \
       --namespace ${var.namespace} \
       ${var.create_namespace ? "--create-namespace" : ""} \
       -f $VALUES_FILE \

--- a/variables.tf
+++ b/variables.tf
@@ -4,8 +4,9 @@ variable "chart_name" {
 }
 
 variable "chart_version" {
+  description = "Version of the Helm chart to install. If not specified, the latest version will be used."
   type        = string
-  description = "Version of the chart"
+  default     = ""
 }
 
 variable "release_name" {


### PR DESCRIPTION
Add logic to use the latest Helm chart version if no specific version
is provided. Update `chart_version` variable to have a default empty
string and improve its description for clarity.
