### PR TITLE
feat: opt-in destroy_command teardown hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+.terraform.lock.hcl

--- a/README.md
+++ b/README.md
@@ -55,14 +55,17 @@ Contributions to improve this module are welcome. Please submit a pull request o
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
+| <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.0.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| <a name="provider_external"></a> [external](#provider\_external) | >= 2.0.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.0.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
@@ -72,7 +75,10 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [null_resource.helm_destroy_hook](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.helm_install](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [terraform_data.bash_required](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [external_external.bash_check](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
 
 ## Inputs
 
@@ -82,6 +88,7 @@ No modules.
 | <a name="input_chart_name"></a> [chart\_name](#input\_chart\_name) | Name of the chart | `string` | n/a | yes |
 | <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Version of the Helm chart to install. If not specified, the latest version will be used. | `string` | `""` | no |
 | <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Create the namespace if it does not exist. Defaults to false | `bool` | `false` | no |
+| <a name="input_destroy_command"></a> [destroy\_command](#input\_destroy\_command) | Bash command run by a `when = destroy` local-exec. Empty string disables the hook (no resource created). The caller is responsible for baking any required env into the command body. | `string` | `""` | no |
 | <a name="input_kubeconfig_json"></a> [kubeconfig\_json](#input\_kubeconfig\_json) | Kubeconfig JSON | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace to install the chart | `string` | n/a | yes |
 | <a name="input_release_name"></a> [release\_name](#input\_release\_name) | Release name of the chart | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -9,28 +9,16 @@ This Terraform module provides a flexible way to install Helm charts on a Kubern
 - Allows for namespace creation
 - Configurable chart values
 - Uses temporary files for secure kubeconfig and values handling
+- Optional pre-destroy teardown hook via `destroy_command`
 
 ## Requirements
 
-- Terraform >= 0.13
+- Terraform >= 1.4.0
 - Helm (installed on the machine running Terraform)
 - Access to a Kubernetes cluster
-
-## Input Variables
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| `chart_name` | Name of the Helm chart to install | `string` | n/a | yes |
-| `chart_version` | Version of the Helm chart to install | `string` | n/a | yes |
-| `release_name` | Name for the Helm release | `string` | n/a | yes |
-| `namespace` | Kubernetes namespace to install the release into | `string` | n/a | yes |
-| `create_namespace` | Whether to create the namespace if it doesn't exist | `bool` | `false` | no |
-| `repo_name` | Name of the Helm repository | `string` | n/a | yes |
-| `repo_url` | URL of the Helm repository | `string` | n/a | yes |
-| `cluster_ca_certificate` | Base64 encoded CA certificate of the Kubernetes cluster | `string` | n/a | yes |
-| `cluster_endpoint` | Endpoint of the Kubernetes cluster | `string` | n/a | yes |
-| `token` | Authentication token for the Kubernetes cluster | `string` | n/a | yes |
-| `set_values` | Map of values to pass to the Helm chart | `any` | `{}` | no |
+- For the optional `destroy_command` hook: `bash` on `PATH`, plus whatever tools
+  the command itself invokes — see
+  [Shell requirement](#shell-requirement-windows-not-supported)
 
 ## How it works
 
@@ -46,6 +34,73 @@ This Terraform module provides a flexible way to install Helm charts on a Kubern
 - The module uses a `null_resource` with a `local-exec` provisioner, which means the Helm commands are executed on the machine running Terraform, not within Terraform itself.
 - Be cautious with sensitive information in `set_values`. While this module uses temporary files, it's generally a good practice to manage secrets separately.
 
+## Shell requirement (Windows not supported)
+
+This module shells out via `local-exec` provisioners, so it requires a POSIX
+shell environment on the machine running Terraform. **Windows-native runners are
+not supported — run from WSL, Linux, or macOS.**
+
+- `null_resource.helm_install` runs under the default `local-exec` shell
+  (`/bin/sh` on Unix) and uses POSIX heredocs plus `helm`. It needs `helm` on
+  `PATH`.
+- The optional `destroy_command` hook (`null_resource.helm_destroy_hook`) runs
+  explicitly under `bash` (`interpreter = ["bash", "-c"]`), so **`bash` must be
+  on `PATH`** for the command to run. The command is caller-supplied and may need
+  additional tools on `PATH` depending on what it does.
+
+There is no plan-time guard for these requirements: a missing shell, `bash`, or
+`helm` surfaces as a provisioner launch/exit failure at `apply`/`destroy` time.
+Because the teardown never starts when `bash` is absent, no partial destroy
+occurs — the operation simply fails. Re-run from a supported environment to
+recover.
+
+### Recovering a `destroy` when `bash` is unavailable
+
+If `null_resource.helm_destroy_hook` is already in state and you run
+`terraform destroy` on a host without `bash`, the destroy **starts** (there is no
+plan-time bash dependency) but fails the moment Terraform invokes the
+`when = destroy` provisioner:
+
+```
+Error: running "bash -c ...": exec: "bash": executable file not found in $PATH
+```
+
+A failed destroy-time provisioner aborts the destroy and leaves the resource in
+state. Because the hook `depends_on` `helm_install`, it is torn down **first**
+(reverse-graph order), so the failure happens before anything else is destroyed —
+nothing is left half-torn-down, and you are in a clean, recoverable spot.
+
+**Option 1 — run the destroy from a `bash`-capable host (preferred, no data loss).**
+Re-run `terraform destroy` from WSL, Linux, or macOS with `bash` (and whatever
+else your `destroy_command` invokes) on `PATH`. The `destroy_command` runs and the
+rest of the stack destroys normally. This is the intended path.
+
+**Option 2 — drop the hook from state and skip the teardown (escape hatch).**
+
+```bash
+terraform state rm 'module.<name>.null_resource.helm_destroy_hook[0]'
+terraform destroy
+```
+
+`state rm` makes Terraform forget the resource **without running its destroy
+provisioner**, so the destroy proceeds without `bash`. The cost: the
+`destroy_command` never runs, so **whatever cloud resources it was responsible for
+cleaning up may be orphaned** — and orphaned resources can block downstream
+destroys (e.g. a VPC that still has attached ENIs). Take this path only if `bash`
+is truly unobtainable, and plan to clean up those resources manually or run your
+`destroy_command` logic separately from a `bash`-capable host.
+
+### Managing the `destroy_command` hook
+
+- The hook's `triggers` are frozen after first apply (`ignore_changes`). To
+  update the script on an existing resource, run
+  `terraform apply -replace='module.<name>.null_resource.helm_destroy_hook[0]'`
+  while the cluster is quiescent.
+- To retire the hook on a live cluster, use
+  `terraform state rm 'module.<name>.null_resource.helm_destroy_hook[0]'` rather
+  than setting `destroy_command = ""` — flipping the count to 0 would fire the
+  captured teardown script.
+
 ## Contributing
 
 Contributions to improve this module are welcome. Please submit a pull request or open an issue on the repository.
@@ -56,16 +111,13 @@ Contributions to improve this module are welcome. Please submit a pull request o
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
-| <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.0.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_external"></a> [external](#provider\_external) | >= 2.0.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.0.0 |
-| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
@@ -77,8 +129,6 @@ No modules.
 |------|------|
 | [null_resource.helm_destroy_hook](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.helm_install](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [terraform_data.bash_required](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
-| [external_external.bash_check](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,12 @@ locals {
   EOT
 }
 
-# Main resource for Helm installation
+# Main resource for Helm installation.
+# Triggers intentionally unchanged from earlier module versions — adding new
+# trigger keys here would force-recreate this resource on upgrade and re-run
+# `helm install` once on every existing cluster (and again on every script edit
+# that affected the new keys). The destroy hook lives in its own resource below
+# so its lifecycle is decoupled from the install.
 resource "null_resource" "helm_install" {
   triggers = {
     chart_name    = var.chart_name
@@ -26,38 +31,77 @@ resource "null_resource" "helm_install" {
   provisioner "local-exec" {
     command = <<-EOT
       echo "Starting Helm install process..."
-      
+
       # Create temporary files
       export KUBECONFIG=$(mktemp)
       VALUES_FILE=$(mktemp)
       echo "Created temporary files: KUBECONFIG=$KUBECONFIG, VALUES_FILE=$VALUES_FILE"
-      
+
       # Generate kubeconfig
       cat <<EOF > $KUBECONFIG
       ${var.kubeconfig_json}
       EOF
       echo "Generated kubeconfig file"
-      
+
       # Generate values file
       cat <<EOF > $VALUES_FILE
       ${jsonencode(var.set_values)}
       EOF
       echo "Generated values file"
-      
+
       # Execute Helm commands
       echo "Executing Helm commands..."
       helm repo add ${var.repo_name} ${var.repo_url}
       helm repo update ${var.repo_name}
       ${local.helm_command}
-      
+
       HELM_EXIT_CODE=$?
       echo "Helm command completed with exit code: $HELM_EXIT_CODE"
-      
+
       # Cleanup
       rm $KUBECONFIG $VALUES_FILE
       echo "Cleaned up temporary files"
-      
+
       exit $HELM_EXIT_CODE
     EOT
+  }
+}
+
+# Optional destroy-time hook, decoupled from helm_install.
+#
+# Why a separate resource (not a second provisioner on helm_install):
+#   - On upgrade from a prior helm-module version, adding triggers to
+#     helm_install would force-recreate it and re-run `helm upgrade --install`
+#     on every existing cluster. The inframold chart is intended to be
+#     bootstrapped once (it carries `helm.sh/resource-policy: keep` and hands
+#     off to ArgoCD), so a forced reinstall has unwanted side effects
+#     (pre-sync hooks re-fire, etc.).
+#   - Iterating on destroy_command (e.g. editing the teardown script) would
+#     also recreate helm_install if they shared triggers. Decoupling means
+#     script edits never touch the install lifecycle.
+#
+# Create-order: depends_on helm_install → so on destroy, this resource is
+# torn down FIRST (reverse-graph order). Its when=destroy provisioner runs
+# while everything (cluster API, controllers, ArgoCD) is still alive.
+# A `count` gate keeps the resource entirely absent when no hook is wanted —
+# so existing clusters that don't yet pass destroy_command see zero new
+# resources in plan, only the install they already have.
+resource "null_resource" "helm_destroy_hook" {
+  count = var.destroy_command != "" ? 1 : 0
+
+  depends_on = [null_resource.helm_install]
+
+  # destroy_command is the only thing the hook needs. We deliberately keep
+  # KUBECONFIG_JSON out of triggers (its token rotates every plan and would
+  # force-recreate the resource every apply); the caller's script body should
+  # build a kubeconfig via `aws eks update-kubeconfig` exec-auth.
+  triggers = {
+    destroy_command = var.destroy_command
+  }
+
+  provisioner "local-exec" {
+    when        = destroy
+    interpreter = ["/bin/bash", "-c"]
+    command     = self.triggers.destroy_command
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -72,64 +72,45 @@ resource "null_resource" "helm_install" {
 # Why a separate resource (not a second provisioner on helm_install):
 #   - On upgrade from a prior helm-module version, adding triggers to
 #     helm_install would force-recreate it and re-run `helm upgrade --install`
-#     on every existing cluster. The inframold chart is intended to be
-#     bootstrapped once (it carries `helm.sh/resource-policy: keep` and hands
-#     off to ArgoCD), so a forced reinstall has unwanted side effects
-#     (pre-sync hooks re-fire, etc.).
-#   - Iterating on destroy_command (e.g. editing the teardown script) would
-#     also recreate helm_install if they shared triggers. Decoupling means
-#     script edits never touch the install lifecycle.
+#     on every existing release. Depending on the chart, a forced reinstall can
+#     have unwanted side effects (e.g. helm hooks re-firing), so we keep the
+#     install lifecycle untouched.
+#   - Iterating on destroy_command (e.g. editing the command) would also
+#     recreate helm_install if they shared triggers. Decoupling means command
+#     edits never touch the install lifecycle.
 #
 # Create-order: depends_on helm_install → so on destroy, this resource is
 # torn down FIRST (reverse-graph order). Its when=destroy provisioner runs
-# while everything (cluster API, controllers, ArgoCD) is still alive.
+# while the release it targets is still present.
 # A `count` gate keeps the resource entirely absent when no hook is wanted —
-# so existing clusters that don't yet pass destroy_command see zero new
+# so existing releases that don't yet pass destroy_command see zero new
 # resources in plan, only the install they already have.
-# Plan-time bash availability check. Surfaces the bash requirement as a clear
-# plan-stage error on Windows-native runners (and any runner missing bash) so
-# operators don't hit a cryptic shell error mid-destroy. Both the install
-# provisioner (interpreter=/bin/bash, uses heredocs and helm) and the destroy
-# hook below require bash; this guard is intentionally scoped to the destroy
-# path because that's where data loss from an unexpected failure is hardest to
-# recover from.
-data "external" "bash_check" {
-  count   = trimspace(var.destroy_command) != "" ? 1 : 0
-  program = ["bash", "-c", "printf '{\"version\":\"%s\"}' \"$BASH_VERSION\""]
-}
-
-resource "terraform_data" "bash_required" {
-  count = trimspace(var.destroy_command) != "" ? 1 : 0
-  lifecycle {
-    precondition {
-      condition     = length(data.external.bash_check) > 0 && data.external.bash_check[0].result.version != ""
-      error_message = "destroy_command requires bash on the runner's PATH. This module does not support Windows-native runners — use WSL/Linux/macOS, or unset destroy_command (the surrounding cluster destroy may then leave orphaned cloud resources)."
-    }
-  }
-}
-
+#
+# destroy_command is an opaque, caller-supplied string: this module does not
+# know or assume what it does. The comments below cover the resource lifecycle
+# only.
 resource "null_resource" "helm_destroy_hook" {
   count = trimspace(var.destroy_command) != "" ? 1 : 0
 
-  depends_on = [null_resource.helm_install, terraform_data.bash_required]
+  depends_on = [null_resource.helm_install]
 
-  # destroy_command is the only thing the hook needs. We deliberately keep
-  # KUBECONFIG_JSON out of triggers (its token rotates every plan and would
-  # force-recreate the resource every apply); the caller's script body should
-  # build a kubeconfig via `aws eks update-kubeconfig` exec-auth.
+  # destroy_command is the only thing the hook tracks in triggers. Anything that
+  # rotates every plan (tokens, generated kubeconfigs, etc.) is deliberately kept
+  # out — including it would force-recreate the resource on every apply. How the
+  # command authenticates to the cluster is the caller's concern.
   triggers = {
     destroy_command = var.destroy_command
   }
 
   # Freeze triggers after first apply. Without this, editing var.destroy_command
   # would mutate the trigger, force-replace this resource, and fire the OLD
-  # destroy script during a routine apply against a live cluster — wiping
-  # Karpenter EC2 + Istio NLB when the operator only intended a config edit.
-  # Trade-off: script updates require `terraform apply
+  # destroy command during a routine apply against a live cluster — running a
+  # teardown the operator never intended when they only meant to edit config.
+  # Trade-off: command updates require `terraform apply
   # -replace=module.<name>.null_resource.helm_destroy_hook[0]` while the
   # cluster is quiescent. To retire the hook on a live cluster, use
   # `terraform state rm` rather than setting destroy_command = "" (a count
-  # flip to 0 would also fire the captured script).
+  # flip to 0 would also fire the captured command).
   lifecycle {
     ignore_changes = [triggers]
   }

--- a/main.tf
+++ b/main.tf
@@ -121,6 +121,19 @@ resource "null_resource" "helm_destroy_hook" {
     destroy_command = var.destroy_command
   }
 
+  # Freeze triggers after first apply. Without this, editing var.destroy_command
+  # would mutate the trigger, force-replace this resource, and fire the OLD
+  # destroy script during a routine apply against a live cluster — wiping
+  # Karpenter EC2 + Istio NLB when the operator only intended a config edit.
+  # Trade-off: script updates require `terraform apply
+  # -replace=module.<name>.null_resource.helm_destroy_hook[0]` while the
+  # cluster is quiescent. To retire the hook on a live cluster, use
+  # `terraform state rm` rather than setting destroy_command = "" (a count
+  # flip to 0 would also fire the captured script).
+  lifecycle {
+    ignore_changes = [triggers]
+  }
+
   provisioner "local-exec" {
     when        = destroy
     interpreter = ["/bin/bash", "-c"]

--- a/main.tf
+++ b/main.tf
@@ -94,12 +94,12 @@ resource "null_resource" "helm_install" {
 # path because that's where data loss from an unexpected failure is hardest to
 # recover from.
 data "external" "bash_check" {
-  count   = var.destroy_command != "" ? 1 : 0
+  count   = trimspace(var.destroy_command) != "" ? 1 : 0
   program = ["bash", "-c", "printf '{\"version\":\"%s\"}' \"$BASH_VERSION\""]
 }
 
 resource "terraform_data" "bash_required" {
-  count = var.destroy_command != "" ? 1 : 0
+  count = trimspace(var.destroy_command) != "" ? 1 : 0
   lifecycle {
     precondition {
       condition     = length(data.external.bash_check) > 0 && data.external.bash_check[0].result.version != ""
@@ -109,7 +109,7 @@ resource "terraform_data" "bash_required" {
 }
 
 resource "null_resource" "helm_destroy_hook" {
-  count = var.destroy_command != "" ? 1 : 0
+  count = trimspace(var.destroy_command) != "" ? 1 : 0
 
   depends_on = [null_resource.helm_install, terraform_data.bash_required]
 
@@ -136,7 +136,7 @@ resource "null_resource" "helm_destroy_hook" {
 
   provisioner "local-exec" {
     when        = destroy
-    interpreter = ["/bin/bash", "-c"]
+    interpreter = ["bash", "-c"]
     command     = self.triggers.destroy_command
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -86,10 +86,32 @@ resource "null_resource" "helm_install" {
 # A `count` gate keeps the resource entirely absent when no hook is wanted —
 # so existing clusters that don't yet pass destroy_command see zero new
 # resources in plan, only the install they already have.
+# Plan-time bash availability check. Surfaces the bash requirement as a clear
+# plan-stage error on Windows-native runners (and any runner missing bash) so
+# operators don't hit a cryptic shell error mid-destroy. Both the install
+# provisioner (interpreter=/bin/bash, uses heredocs and helm) and the destroy
+# hook below require bash; this guard is intentionally scoped to the destroy
+# path because that's where data loss from an unexpected failure is hardest to
+# recover from.
+data "external" "bash_check" {
+  count   = var.destroy_command != "" ? 1 : 0
+  program = ["bash", "-c", "printf '{\"version\":\"%s\"}' \"$BASH_VERSION\""]
+}
+
+resource "terraform_data" "bash_required" {
+  count = var.destroy_command != "" ? 1 : 0
+  lifecycle {
+    precondition {
+      condition     = length(data.external.bash_check) > 0 && data.external.bash_check[0].result.version != ""
+      error_message = "destroy_command requires bash on the runner's PATH. This module does not support Windows-native runners — use WSL/Linux/macOS, or unset destroy_command (the surrounding cluster destroy may then leave orphaned cloud resources)."
+    }
+  }
+}
+
 resource "null_resource" "helm_destroy_hook" {
   count = var.destroy_command != "" ? 1 : 0
 
-  depends_on = [null_resource.helm_install]
+  depends_on = [null_resource.helm_install, terraform_data.bash_required]
 
   # destroy_command is the only thing the hook needs. We deliberately keep
   # KUBECONFIG_JSON out of triggers (its token rotates every plan and would

--- a/providers.tf
+++ b/providers.tf
@@ -1,10 +1,16 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.4.0"
 
   required_providers {
     null = {
       source  = "hashicorp/null"
       version = ">= 3.0.0"
+    }
+    # data.external used by the optional bash_check below. Only consulted when
+    # the caller sets destroy_command; otherwise no plan-time bash dependency.
+    external = {
+      source  = "hashicorp/external"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -6,11 +6,5 @@ terraform {
       source  = "hashicorp/null"
       version = ">= 3.0.0"
     }
-    # data.external used by the optional bash_check below. Only consulted when
-    # the caller sets destroy_command; otherwise no plan-time bash dependency.
-    external = {
-      source  = "hashicorp/external"
-      version = ">= 2.0.0"
-    }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -73,4 +73,9 @@ variable "destroy_command" {
   description = "Bash command run by a `when = destroy` local-exec. Empty string disables the hook (no resource created). The caller is responsible for baking any required env into the command body."
   type        = string
   default     = ""
+
+  validation {
+    condition     = trimspace(var.destroy_command) == var.destroy_command
+    error_message = "destroy_command must not have leading or trailing whitespace; use \"\" to disable the hook."
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -51,3 +51,26 @@ variable "kubeconfig_json" {
   description = "Kubeconfig JSON"
   type        = string
 }
+
+# -----------------------------------------------------------------------------
+# Optional destroy-time hook
+# -----------------------------------------------------------------------------
+# Generic "run this bash on tofu destroy" escape hatch so callers can clean up
+# cloud resources the chart created out-of-band (e.g. Karpenter EC2 instances,
+# AWS-LB-Controller NLBs) BEFORE the surrounding cluster/network is torn down.
+# Empty string disables the hook entirely (no resource created).
+#
+# The hook lives in a separate null_resource (helm_destroy_hook) so its
+# lifecycle is decoupled from the helm install — script edits do not force
+# `helm install` to re-run. Any env the script needs must be baked into the
+# command string by the caller (triggers only hold strings, so we deliberately
+# don't accept a map; we also don't put KUBECONFIG_JSON in the env because its
+# token rotates every plan, which would defeat the decoupling. The recommended
+# pattern is for the script body to build its own kubeconfig via
+# `aws eks update-kubeconfig` exec-auth using cluster_name + region baked into
+# the command string).
+variable "destroy_command" {
+  description = "Bash command run by a `when = destroy` local-exec. Empty string disables the hook (no resource created). The caller is responsible for baking any required env into the command body."
+  type        = string
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -75,7 +75,7 @@ variable "destroy_command" {
   default     = ""
 
   validation {
-    condition     = trimspace(var.destroy_command) == var.destroy_command
-    error_message = "destroy_command must not have leading or trailing whitespace; use \"\" to disable the hook."
+    condition     = var.destroy_command == "" || trimspace(var.destroy_command) != ""
+    error_message = "destroy_command must be empty (\"\") to disable, or contain non-whitespace content."
   }
 }


### PR DESCRIPTION
## Why

When destroying a Truefoundry-managed AWS cluster, Terraform regularly wedged on `DependencyViolation` during VPC teardown. Karpenter-provisioned EC2 instances and the Istio gateway's AWS NLB are owned by **in-cluster controllers** (Karpenter, AWS Load Balancer Controller) that Terraform never sees. On `tofu destroy`, those controllers die before they can release their cloud resources → orphaned EC2 + ENIs → node security group → VPC → cluster all refuse to delete.

The historical workaround was manual: `kubectl delete nodepools`, force-strip NodeClaim finalizers, `aws ec2 terminate-instances` by tag. Painful, error-prone, and a hard blocker for unattended e2e testing.

This PR adds the **generic mechanism** that lets callers attach a pre-destroy teardown script to the helm release. The AWS platform template uses it to wire in a Karpenter/Istio cleanup script. Tracking: [INFRA-687](https://linear.app/truefoundry/issue/INFRA-687/allow-terraform-to-destroy-aws-computecontrol-plane-cluster).

## What this PR adds

A new opt-in variable `destroy_command` on the helm module. When non-empty:
- A `null_resource.helm_destroy_hook` is created (count-gated on `trimspace(var.destroy_command) != ""`), as a **separate resource** from `helm_install` so its lifecycle is decoupled — upgrades never re-run `helm upgrade --install` and command edits never touch the install.
- Its `when = destroy` provisioner runs the supplied command via `bash -c` (`interpreter = ["bash", "-c"]`, PATH-resolved).
- `lifecycle { ignore_changes = [triggers] }` freezes the captured command after first apply so trigger edits never force-replace the resource (which would fire the destroy provisioner during a routine apply against a live cluster).
- A `validation` rule on `destroy_command` rejects all-whitespace values to prevent silent no-op hooks.

`destroy_command` is treated as an **opaque, caller-supplied string** — the module makes no assumptions about what it does (the inline comments and README were scrubbed of caller-specific details accordingly).

When `destroy_command = ""` (the default), zero new resources are materialized — fully backwards-compatible.

### No plan-time bash guard (changed during review)

An earlier revision of this PR added a `terraform_data.bash_required` precondition (backed by a `data.external.bash_check`) to fail fast at plan time when `bash` was missing. **It has been removed.** Review concluded it didn't earn its keep:

- It was **unreachable in the primary failure case** — when `bash` is absent, the `data.external` read fails first with a generic provider error, before the precondition is ever evaluated.
- Half its condition (`length(...) > 0`) was **tautological** under the shared `count` gate.
- It was **inconsistent** with `null_resource.helm_install`, which is also unguarded and simply fails loudly under a shell it can't run. A Windows-native runner can't use the module at all (it fails at install), so a destroy-only guard protected a path a fresh runner never reaches.

The module now relies on the same loud-provisioner-failure behavior for both paths, documents the shell/bash requirement + recovery in the README, and **drops the `hashicorp/external` provider dependency** entirely.

## Architecture

```mermaid
graph TD
    A[var.destroy_command<br/>caller-supplied bash] -->|count=1 when non-empty| D
    C[null_resource.helm_install<br/>existing chart bootstrap] -->|depends_on| D
    D[null_resource.helm_destroy_hook<br/>when=destroy local-exec<br/>ignore_changes = triggers]
    D -->|on tofu destroy| E[caller's bash command]
```

On destroy, reverse-graph order fires the hook **first**: `helm_destroy_hook` runs the caller's command → then `helm_install` (no-op, no destroy provisioner). The command therefore runs while the release it targets is still present. Then the surrounding modules (EKS, ALB IAM, Karpenter IAM, EFS, network…) tear down without dependency violations because the cloud resources their state depends on are already gone.

## Backwards compatibility

| Caller state | Behaviour with this version |
|---|---|
| Does not set `destroy_command` | No new resources. Identical to prior helm-module versions. |
| Sets `destroy_command = ""` | Same as above (explicit opt-out). |
| Sets `destroy_command = "<bash>"` on a runner with bash | Hook attaches; destroy fires the command before helm_install is removed. |
| Sets `destroy_command` on a runner WITHOUT bash | No plan-time failure. The `when = destroy` provisioner fails to launch at destroy time (`exec: "bash": executable file not found in $PATH`); because it never starts, no partial teardown occurs and (since the hook is torn down first) nothing else is destroyed. Recover by re-running from a bash-capable host, or `terraform state rm` the hook to skip it. |
| Edits `destroy_command` after first apply on a live cluster | No-op at plan time (triggers frozen). To update the captured command, run `terraform apply -replace=module.<name>.null_resource.helm_destroy_hook[0]` during a quiescent window. To retire the hook, use `terraform state rm` rather than `destroy_command = ""` (count→0 still fires the captured command). |

The `triggers` map on `null_resource.helm_install` was **deliberately not modified** — existing clusters upgrading to this version see no forced `helm upgrade --install` re-run. First plan after upgrade is `1 to add, 0 to change, 0 to destroy` (just the new hook).

## Testing

> **Note (final design):** the plan-time bash precondition referenced in Phase 5 below (`terraform_data.bash_required` / `data.external.bash_check`) was **removed before merge** — see "No plan-time bash guard" above. Mentions of those resources in the history below describe an intermediate state of the branch.

Dev was structured so the destructive full-destroy step ran exactly **once per validated path**:

- **Phase 1** — script developed standalone, iterated non-destructively on a live cluster, using `argocd app sync` as the reset button between runs.
- **Phase 2** — Terraform `when = destroy` mechanics (trigger capture, `self.triggers.*` references, env injection) validated via a throwaway one-resource TF config pointed at the live cluster.
- **Phase 3** — Wired into the AWS platform template; all 7 testdata fixtures pass `render-and-validate.sh`.
- **Phase 4 (graceful)** — Real Scalr-driven `apply→destroy` on cluster `tfy-im-jeff-aws-cmp-01-happy`. Script ran 160s (33s NLB drain, 111s Karpenter drain). Terraform destroyed all 128 resources cleanly. AWS post-check showed 0 leftover EC2/LBs.
- **Phase 4.5 (forceful)** — Live test on cluster `tfy-im-jeff-aws-cmp-01-force` with Karpenter and AWS-LB-Controller deliberately scaled to 0. Script ran 279s: NLB-drain wait timed out (60s) → Karpenter-drain wait timed out (60s) → 3 NodeClaim finalizers stripped via JSON Patch → AWS-CLI sweep terminated 3 EC2 + deleted 1 NLB by tag. Final state: 0 leftovers, exit 0.

### Phase 5 — Review fixes + smoke validation

Three rounds of [Cursor Bugbot](https://cursor.com/bugbot) findings landed during review and were addressed:

- **`e1156f9`** — *high-sev*: editing `destroy_command` on a live cluster would force-replace `helm_destroy_hook` and fire the OLD captured script during a routine apply. Fixed by adding `lifecycle { ignore_changes = [triggers] }`.
- **`e905bcd`** — *medium-sev* (two findings): (a) destroy provisioner hardcoded `/bin/bash` while the plan-time check used PATH lookup (NixOS-class miss); (b) `var.destroy_command != ""` accepted whitespace-only values and silently created a no-op hook. Fixed by `interpreter = ["bash", "-c"]`, `trimspace()` gates, and a `validation` block.
- **`da9fbd7`** — caught by the live-plan smoke test below: initial validation rule was too strict (`trimspace(x) == x`) and rejected real bash scripts that end with a trailing newline. Loosened to reject only all-whitespace values.

A subsequent (fourth) Bugbot finding flagged the `terraform_data.bash_required` precondition as unreachable/tautological; rather than patch it, the bash-check apparatus was removed (see "No plan-time bash guard"), and the README gained the shell-requirement + destroy-recovery docs.

Smoke-test plan executed against the fixed branch:

- **Tier 1 (standalone harness)** — local `null_resource` harness mirroring the hook structure. Verified: trigger edit produces 0 changes; destroy fires the captured (frozen) script, not the current value; count→0 still fires (documented hazard); `terraform state rm` is a clean disable path; whitespace-only values rejected at plan via both `-var` and `.tfvars`; real scripts with trailing newline accepted.
- **Tier 2 (render + validate)** — rendered the aws-platform bundle with `pre_destroy_cleanup.enabled = true`, swapped the helm source to this PR's HEAD, ran `tofu init && tofu validate`. The rendered HCL wires `destroy_command` correctly; backwards-compat path (no opt-in) renders without the `destroy_command` line and validates against an older helm pin.
- **Tier 3 (live plan-only)** — bumped the IM bundle's helm pin to this PR's HEAD and ran plan-only Scalr runs against the existing live cluster `tfy-im-jeff-aws-cmp-01-happy` (which already has the hook in state from an earlier helm pin):
  - **T7 (no-op upgrade plan)**: 0 resource changes on `helm_destroy_hook`. The `lifecycle` block is a meta-argument (no drift detection), the `interpreter` change is provisioner config (no replacement), `trimspace()` evaluates count-equivalent for a non-empty script.
  - **T8 (cosmetic script edit)**: appended a benign `echo` to the rendered teardown script. Same hook `id` retained, refreshing-state only, **no replacement** — `ignore_changes = [triggers]` hid the trigger drift end-to-end. Without the fix, this exact plan would have replaced the hook and fired the V1 captured script against the live cluster.

## Companion changes

- **`tfy-infra-templates`** — already merged to `main`: [`9c5c922...fe09797`](https://github.com/truefoundry/tfy-infra-templates/compare/9c5c922...fe09797) (3 commits: AWS Karpenter/Istio teardown script wired via `destroy_command`, uniform git-source pattern across all 3 clouds, version reset to `0.0.1`).
- **`tfy-infra-manager`** — https://github.com/truefoundry/tfy-infra-manager/pull/30 — IM force-sets `pre_destroy_cleanup.enabled=true` for IM-managed aws-platform deploys so the hook attaches automatically during internal preview.

## Risks / flags

- **Runner toolchain**: needs `bash` plus whatever the caller's command invokes (typically `kubectl`/`aws`). There is **no plan-time guard** — a missing `bash` surfaces as a provisioner launch failure at apply/destroy, with no partial teardown (the hook is torn down first, so nothing else is destroyed). See the README "Shell requirement" + recovery sections.
- **`exit 0` masks failures by design**: the destroy provisioner runs the command with whatever shell exit semantics the caller chooses. The AWS platform script uses `FAIL_ON_ERROR=false` so it reports leftovers in its log without wedging an otherwise-progressing destroy.
- **Operator discipline for command updates**: `ignore_changes = [triggers]` means a command edit after first apply requires `terraform apply -replace=...` to take effect; retiring the hook requires `terraform state rm` (not `destroy_command = ""`). Both behaviours are documented inline in `main.tf` and in the README.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in destroy hooks change teardown order and can orphan cloud resources if bash is missing or operators skip the hook via state rm; default empty command preserves prior behavior.
> 
> **Overview**
> Adds an opt-in **`destroy_command`** input that, when non-empty, creates **`null_resource.helm_destroy_hook`**: a separate resource from **`helm_install`** so upgrades do not re-run Helm or change install triggers. On destroy, the hook runs first (via **`depends_on`**) and executes caller-supplied bash through **`when = destroy`** / **`bash -c`**. Triggers are frozen with **`lifecycle { ignore_changes = [triggers] }`** so script edits do not replace the resource and accidentally run teardown on apply; whitespace-only values are rejected by validation.
> 
> **Terraform minimum version** is raised from **>= 0.13.0** to **>= 1.4.0**. README documents POSIX/bash/helm runner requirements, destroy recovery (**`state rm`** escape hatch), and hook update/replace workflows. **`.terraform.lock.hcl`** is added to **`.gitignore`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ef2659dee3e1988fd4717e90e094b49e086973c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
